### PR TITLE
gcc-9 build testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ ${LIB_CORE}: ${CORE_OBJS}
 	${CXX} ${CXXFLAGS} ${VEC_HOST} ${CORE_OBJS} -shared -o $@ ${LDFLAGS_HOST} ${LDFLAGS_CU} ${LDFLAGS}
 
 main: ${AUTO_TGTS} ${LIB_CORE} main.o ${LIBUSOLIDS}
-	${CXX} ${CXXFLAGS} ${VEC_HOST} -o $@ main.o ${LIBUSOLIDS} ${LDFLAGS_HOST} ${LDFLAGS} -Llib -lMicCore -Wl,-rpath,lib
+	${CXX} ${CXXFLAGS} ${VEC_HOST} -o $@ main.o ${LIBUSOLIDS} ${LDFLAGS_HOST} ${LDFLAGS} -Llib -lMicCore -Wl,-rpath,lib ${OTHER_LIB}
 
 ${OBJS}: %.o: %.cc %.d
 	${CXX} ${CPPFLAGS} ${CXXFLAGS} ${VEC_HOST} -c -o $@ $<

--- a/Makefile.config
+++ b/Makefile.config
@@ -182,10 +182,11 @@ else
   VEC_HOST := ${VEC_GCC}
 endif
 
-ifeq ($(CXX), g++)
+ifeq ($(findstring g++,$(CXX)), g++)
   CXXFLAGS += -std=c++1z -ftree-vectorize -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=address -Werror=format -Werror=write-strings -Werror=delete-non-virtual-dtor -Wstrict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder  -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi
 #Removed  -Werror=sign-compare, -Werror=unused-variable 
   CXXFLAGS += -fdiagnostics-color=always -fdiagnostics-show-option -pthread -pipe -fopenmp
+  OTHER_LIB = -ldl
 endif
 
 ifdef WITH_USOLIDS

--- a/mkFit/Makefile
+++ b/mkFit/Makefile
@@ -9,7 +9,12 @@
 include ../Makefile.config
 
 CPPEXTRA := -I.. ${USER_CPPFLAGS} ${DEFS}
-LDEXTRA  := -ltbb ${USER_LDFLAGS}
+ifdef WITH_TBB
+  LDEXTRA  := -ltbb ${USER_LDFLAGS}
+else
+  LDEXTRA  := ${USER_LDFLAGS}
+endif
+
 
 CPPFLAGS := ${CPPEXTRA} ${CPPFLAGS}
 CXXFLAGS += ${USER_CXXFLAGS}

--- a/mkFit/MkFinderFV.cc
+++ b/mkFit/MkFinderFV.cc
@@ -218,14 +218,19 @@ void MkFinderFV<nseeds, ncands>::SelectHitIndices(const LayerOfHits &layer_of_hi
       << pb1[iseed] << "-" << pb2[iseed]);
   }
 
+#ifdef  MPLEX_USE_INTRINSICS
   _mm_prefetch((const char*) &L.m_phi_bin_infos[qb1[0]][pb1[0] & L.m_phi_mask], _MM_HINT_T0);
+#endif
 
   for (auto iseed = 0; iseed < nseeds; ++iseed) {
     const int base = iseed*ncands;
     for (int qi = qb1[iseed]; qi < qb2[iseed]; ++qi) {
+
+#ifdef  MPLEX_USE_INTRINSICS
       if (qi+1 < qb2[iseed]) {
         _mm_prefetch((const char*) &L.m_phi_bin_infos[qi+1][pb1[iseed] & L.m_phi_mask], _MM_HINT_T0);
       }
+#endif
       for (int pi = pb1[iseed]; pi < pb2[iseed]; ++pi) {
         int pb = pi & L.m_phi_mask;
         for (int hi = L.m_phi_bin_infos[qi][pb].first; hi < L.m_phi_bin_infos[qi][pb].second; ++hi) {

--- a/mkFit/mkFit.cc
+++ b/mkFit/mkFit.cc
@@ -1,7 +1,7 @@
 #include "Matriplex/MatriplexCommon.h"
 
-#include "fittestMPlex.h"
-#include "buildtestMPlex.h"
+//#include "fittestMPlex.h"
+//#include "buildtestMPlex.h"
 
 #include "MkBuilder.h"
 #include "MkFitter.h"
@@ -33,7 +33,9 @@
 //#define DEBUG
 #include "Debug.h"
 
+#ifdef TBB
 #include <tbb/task_scheduler_init.h>
+#endif
 
 #if defined(USE_VTUNE_PAUSE)
 #include "ittnotify.h"
@@ -215,7 +217,9 @@ void generate_and_save_tracks()
 
   printf("writing %i events\n", Nevents);
 
+#ifdef TBB
   tbb::task_scheduler_init tbb_init(Config::numThreadsSimulation);
+#endif
 
   Event ev(geom, *val, 0);
   for (int evt = 0; evt < Nevents; ++evt)
@@ -303,8 +307,10 @@ void test_standard()
   double time = dtime();
 
 #if USE_CUDA_OLD
+#ifdef TBB
   tbb::task_scheduler_init tbb_init(Config::numThreadsFinder);
   //tbb::task_scheduler_init tbb_init(tbb::task_scheduler_init::automatic);
+#endif
 
   //omp_set_num_threads(Config::numThreadsFinder);
   // fittest time. Sum of all events. In case of multiple events
@@ -386,7 +392,9 @@ void test_standard()
 #endif
   }
 
+#ifdef TBB
   //  tbb::task_scheduler_init tbb_init(Config::numThreadsFinder);
+#endif
 
   dprint("parallel_for step size " << (Config::nEvents+Config::numThreadsEvents-1)/Config::numThreadsEvents);
 
@@ -394,9 +402,11 @@ void test_standard()
 
 
   int events_per_thread = (Config::nEvents+Config::numThreadsEvents-1)/Config::numThreadsEvents;
+#ifdef TBB
   //tbb::parallel_for(tbb::blocked_range<int>(0, Config::numThreadsEvents, 1),
   //  [&](const tbb::blocked_range<int>& threads)
   //{
+#endif
 #pragma omp parallel for 
   for(int thisthread = 0; thisthread< Config::numThreadsEvents; thisthread++)
     {
@@ -506,7 +516,9 @@ void test_standard()
       if (evt > 0) for (int i = 0; i < NT; ++i) t_skip[i] += t_best[i];
     } //end of loop over events 
     }
+#ifdef TBB
   //  }, tbb::simple_partitioner()); //end of tbb parallel for
+#endif
 
 #endif
   time = dtime() - time;


### PR DESCRIPTION
After removing (temporarily) the following files: buildtestMPlex.cc  buildtestMPlex.h  fittestMPlex.cc   fittestMPlex.h, the only non-isolated use of TBB remains in MkBuilder.cc (needed by mkFit.cc) -- once that is fixed, I believe the full build will succeed.  I suppose the relevant code in mkFit.cc can also be commented out temporarily, but I did not do that. Note that on Power9 I had to explicitly link -ldl.
